### PR TITLE
freshen

### DIFF
--- a/assemble-songs.sh
+++ b/assemble-songs.sh
@@ -50,15 +50,18 @@ do
     pushd "$station" > /dev/null
     for file in *.ogg
     do
-        base="`basename "$file" .ogg`"
-        if [ -f "$base (Intro).ogg" -a -f "$base (Outro).ogg" ]
+        inner="${file%.ogg}"
+        base="${inner#[0-9][0-9][0-9] - }"
+        intro=$(echo [0-9][0-9][0-9]" - $base (Intro).ogg")
+        outro=$(echo [0-9][0-9][0-9]" - $base (Outro).ogg")
+        if [ "${intro:0:5}" != "[0-9]" -a "${outro:0:5}" != "[0-9]" ]
         then
             echo "Assembling song $base"
-            cat "$base (Intro).ogg" "$base.ogg" "$base (Outro).ogg" > "$base (Complete).ogg"
+            cat "$outro" "$file" "$outro" > "$inner (Complete).ogg"
             if [ $DELETE -eq 1 ]
             then
                 echo "Deleting leftover parts of song $base"
-                rm -f "$base"\ \(Intro*\).ogg "$base.ogg" "$base"\ \(Outro*\).ogg
+                rm -f "$file" [0-9][0-9][0-9]" - $base ("{In,Ou}tro*").ogg"
             fi
         fi
     done

--- a/metadata.conf
+++ b/metadata.conf
@@ -191,20 +191,27 @@ track40.title = Clip 40
 [fa900b4aca54c5a6c419fda136374f6a]
 station = Beats
 
-track1.title = Dance track 1 (Hollywood swinging)
+track1.title = Dance track (Hollywood swinging)
 track1.artist = Kool and the gang
 track2.title = Intro music
 track3.title = Four dragons casino ambience
 track4.title = Caligula's palace ambience
-track5.title = Dance track 2 (Hollywood swinging)
+track5.title = Dance track (Hollywood swinging)
 track5.artist = Kool and the gang
-track6.title = Dance track 3 (Odyssey)
+track6.title = Dance track (Odyssey)
 track6.artist = Johnny Harris
-track7.title = Dance track 4 (West coast poplock)
+track7.title = Dance track (West coast poplock)
 track7.artist = Ronnie Hudson
 track8.title = Mission complete 1
 track9.title = Mission complete 2
 track10.title = Intro movie
+
+# Alternate md5 for nightclub tracks
+[8b99240953935b0345bed96b23bc2721] = [fa900b4aca54c5a6c419fda136374f6a]
+
+# one track was replaced in this version
+track4.title = Dance track (Nuthin' but a 'G' thang)
+track4.author = Dr Dre
 
 [a88eb0130acb81b5956e412db06ea9ce]
 station = Playback FM
@@ -436,6 +443,9 @@ track127.title = The godfather (Intro DJ 2)
 track128.title = The godfather (Outro)
 track129.title = The godfather (Outro DJ 1)
 track130.title = The godfather (Outro DJ 2)
+
+# Alternate md5 for Playback FM
+[056a3c5a99fe4222f8ba9beeb98de568] = [a88eb0130acb81b5956e412db06ea9ce]
 
 [c2075553325e7fe8d3d50fefff857aa7]
 station = KROSE
@@ -1006,6 +1016,9 @@ track154.title = Free bird (Outro)
 track155.title = Free bird (Outro DJ 1)
 track156.title = Free bird (Outro DJ 2)
 
+# Alternate md5 for K-DST
+[11a670213e7803872d73503873d8a479] = [06a63d4222209a1d6e8ce2e7ace51956]
+
 [d4bcb8ae560e44080169e2b4a5ad03b8]
 station = Cutscene
 
@@ -1150,6 +1163,9 @@ track138.title = Clip 138
 track139.title = Clip 139
 track140.title = Clip 140
 track141.title = Clip 141
+
+# Alternate md5 for Cutscene
+[60830413ba2ce0a103e228e91adbe4e1] = [d4bcb8ae560e44080169e2b4a5ad03b8]
 
 [bbf21458f45989c1edaab9a61b13878b]
 station = Bounce FM
@@ -1469,6 +1485,9 @@ track176.title = Odyssey (Intro DJ 2)
 track177.title = Odyssey (Outro)
 track178.title = Odyssey (Outro DJ 1)
 track179.title = Odyssey (Outro DJ 2)
+
+# Alternate md5 for Bounce FM
+[133045ed658c180481fd298e29a21a41] = [bbf21458f45989c1edaab9a61b13878b]
 
 [2c42bd257849aa8fddb23a70785b5e8c]
 station = SFUR
@@ -1959,6 +1978,9 @@ track150.title = The ghetto (Outro)
 track151.title = The ghetto (Outro DJ 1)
 track152.title = The ghetto (Outro DJ 2)
 
+# Alternate md5 for Radio Los Santos
+[1e3a881621d466e9972213c6ed9b21d4] = [fcc7b4550abb177ea52aee563e562be5]
+
 [4fd83ffca7302ef1d952ba686c0cae32]
 station = Radio X
 
@@ -2225,6 +2247,9 @@ track147.artist = Stone temple pilots
 track145.title = Plush
 track146.title = Plush (Intro)
 track147.title = Plush (Outro)
+
+# Alternate md5 for Radio X
+[3483c1c0bf6c76696dc9208d84562757] = [4fd83ffca7302ef1d952ba686c0cae32]
 
 [80b7cf701f555fc567e1254e7734cb0f]
 station = CSR
@@ -2754,6 +2779,9 @@ track159.title = Bam bam (Intro DJ 2)
 track160.title = Bam bam (Outro)
 track161.title = Bam bam (Outro DJ 1)
 
+# Alternate md5 for K-JAH
+[468c77c46777bf877de765aad8043b0c] = [65e0bea63444d87f74f6ef25388310b7]
+
 [743b480e6182f0a7795cddb2172cf45f]
 station = Master Sounds
 
@@ -3060,6 +3088,9 @@ track167.title = Smokin' cheeba cheeba (Intro DJ 2)
 track168.title = Smokin' cheeba cheeba (Outro)
 track169.title = Smokin' cheeba cheeba (Outro DJ 1)
 track170.title = Smokin' cheeba cheeba (Outro DJ 2)
+
+# Alterante md5 for Master Sounds
+[c6bad41f7c1da17516d7a3819c1bcbb4] = [743b480e6182f0a7795cddb2172cf45f]
 
 [cda6d4299457eff44b33a7f1cb1d2a72]
 station = WCTR

--- a/src/config.h
+++ b/src/config.h
@@ -68,7 +68,7 @@ public:
     * \param def The default value. Returned if the key was not found.
     * \return The key's value or the default value.
     */
-   std::string lookup(const std::string &key, const std::string &def) const;
+   std::string lookup(const std::string &ns, const std::string &key, const std::string &def) const;
 
 private:
 


### PR DESCRIPTION
 * Adds metadata syntax to use one md5 as a base for another
 * Adds new md5s for recent releases
 * Adds track number to filenames
 * Updates assemble-songs.sh to cope with track numbers